### PR TITLE
Line 170 in this class throws error in php 8.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,11 +6,11 @@ When contributing please ensure you follow the guidelines below so that we can k
 
 __Note:__
 
-GitHub is for *bug reports and contributions only* - if you have a support question or a request for a customization, don't post here. Use [WooThemes Support](http://support.woothemes.com) for customer support, [WordPress.org](http://wordpress.org/support/plugin/woosidebars) for community support, and for customisations we recommend one of the following services:
+GitHub is for *bug reports and contributions only* - if you have a support question or a request for a customization, don't post here. Use [WordPress.org](http://wordpress.org/support/plugin/woosidebars) for community support, and for customisations we recommend one of the following services:
 
 - Codeable: http://codeable.io/
 - Tweaky: https://www.tweaky.com/
-- Affiliated Woo Workers: http://www.woothemes.com/affiliated-woo-workers/
+- WooExperts: http://www.woocommerce.com/experts/
 
 ## Getting Started
 
@@ -35,5 +35,5 @@ At this point you're waiting on us to merge your pull request. We'll review all 
 
 * [General GitHub documentation](http://help.github.com/)
 * [GitHub pull request documentation](http://help.github.com/send-pull-requests/)
-* [WooSidebars Docs](http://docs.woothemes.com/documentation/plugins/woosidebars/)
-* [WooThemes Support](http://support.woothemes.com/)
+* [WooSidebars Docs](http://docs.woocommerce.com/documentation/plugins/woosidebars/)
+* [WooCommerce Support](http://woocommerce.com/my-account/tickets/)

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooSidebars Changelog ***
 
+2018.06.18 - version 1.4.5
+ * Fix - Fixes a fatal error, by removing the no longer relevant contextual help.
+
 2018.06.08 - version 1.4.4
  * New - Enable a widget area for "a page and it's children".
  * Fix - Error notice when on a page without a defined screen_id.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,9 @@
 *** WooSidebars Changelog ***
 
+2018.06.08 - version 1.4.4
+ * New - Enable a widget area for "a page and it's children".
+ * Fix - Error notice when on a page without a defined screen_id.
+
 2015.09.22 - version 1.4.3
  * Fix - Ensures condition headings are present before attempting to output in the conditions meta box.
    /classes/class-woo-conditions.php

--- a/classes/class-woo-conditions.php
+++ b/classes/class-woo-conditions.php
@@ -116,33 +116,8 @@ class Woo_Conditions {
 		// Get an array of the different post status labels, in case we need it later.
 		$post_statuses = get_post_statuses();
 
-		// Pages
+		// Pages and Pages with children
 		$conditions['pages'] = array();
-
-		$statuses_string = join( ',', array_keys( $post_statuses ) );
-		$pages = get_pages( array( 'post_status' => $statuses_string ) );
-
-		if ( count( $pages ) > 0 ) {
-
-			$conditions_headings['pages'] = __( 'Pages', 'woosidebars' );
-
-			foreach ( $pages as $k => $v ) {
-				$token = 'post-' . $v->ID;
-				$label = esc_html( $v->post_title );
-				if ( 'publish' != $v->post_status ) {
-					$label .= ' (' . $post_statuses[$v->post_status] . ')';
-				}
-
-				$conditions['pages'][$token] = array(
-									'label' => $label,
-									'description' => sprintf( __( 'The "%s" page', 'woosidebars' ), $v->post_title )
-									);
-			}
-
-		}
-
-
-		// Pages and their children
 		$conditions['pages_with_children'] = array();
 
 		$statuses_string = join( ',', array_keys( $post_statuses ) );
@@ -150,23 +125,32 @@ class Woo_Conditions {
 
 		if ( count( $pages ) > 0 ) {
 
+			$conditions_headings['pages'] = __( 'Pages', 'woosidebars' );
 			$conditions_headings['pages_with_children'] = __( 'Pages and their children', 'woosidebars' );
 
 			foreach ( $pages as $k => $v ) {
-				$token = 'postwc-' . $v->ID;
+				$token = 'post-' . $v->ID;
+				$pwctoken = 'postwc-' . $v->ID;
+
 				$label = esc_html( $v->post_title );
 				if ( 'publish' != $v->post_status ) {
 					$label .= ' (' . $post_statuses[$v->post_status] . ')';
 				}
 
-				$conditions['pages_with_children'][$token] = array(
-									'label' => $label,
-									'description' => sprintf( __( 'The "%s" page and its children', 'woosidebars' ), $v->post_title )
-									);
+				$conditions['pages'][$token] = array(
+					'label' => $label,
+					'description' => sprintf( __( 'The "%s" page', 'woosidebars' ), $v->post_title )
+				);
+
+				$conditions['pages_with_children'][$pwctoken] = array(
+					'label' => $label,
+					'description' => sprintf( __( 'The "%s" page and its children', 'woosidebars' ), $v->post_title ),
+					'parent' => $v->post_parent,
+					'ID' => $v->ID,
+				);
 			}
 
 		}
-
 
 		$args = array(
 					'show_ui' => true,
@@ -563,7 +547,7 @@ class Woo_Conditions {
 
 				if ( 'pages_with_children' === $k ) {
 					$pwc[$k] = $v;
-					unset( $this->conditions_reference[$k] );
+					// unset( $this->conditions_reference[$k] );
 				}
 			}
 

--- a/classes/class-woo-conditions.php
+++ b/classes/class-woo-conditions.php
@@ -375,7 +375,7 @@ class Woo_Conditions {
 	/**
 	 * is_hierarchy function.
 	 *
-	 * @description Is the current view a part of the default template heirarchy?
+	 * @description Is the current view a part of the default template hierarchy?
 	 * @access public
 	 * @return void
 	 */

--- a/classes/class-woo-conditions.php
+++ b/classes/class-woo-conditions.php
@@ -150,6 +150,7 @@ class Woo_Conditions {
 				);
 			}
 
+			$conditions['pages_with_children'] = $this->add_depth( $conditions['pages_with_children'] );
 		}
 
 		$args = array(
@@ -355,6 +356,30 @@ class Woo_Conditions {
 		$this->conditions_reference = (array)apply_filters( 'woo_conditions_reference', $conditions );
 		$this->conditions_headings = (array)apply_filters( 'woo_conditions_headings', $conditions_headings );
 	} // End setup_default_conditions_reference()
+
+
+	private function add_depth( $conditions ) {
+		$map = array();
+		$depth = array();
+		foreach ( $conditions as $condition ) {
+			$map[ $condition['ID'] ] = $condition['parent'];
+		}
+
+		foreach ( $map as $id => $parent ) {
+			$d = 0;
+			while ( 0 != $parent ) {
+				$d++;
+				$parent = $map[$parent];
+			}
+			$depth[$id] = $d;
+		}
+
+		foreach ( $conditions as $key => $condition ) {
+			$conditions[ $key ]['depth'] = $depth[ $condition['ID'] ];
+		}
+
+		return $conditions;
+	}
 
 	/**
 	 * is_hierarchy function.
@@ -625,19 +650,23 @@ class Woo_Conditions {
 				$tab .= '<h4>' . esc_html( $this->conditions_headings[$k] ) . '</h4>' . "\n";
 			}
 			$tab .= '<ul class="alignleft conditions-column">' . "\n";
-				foreach ( $v as $i => $j ) {
-					$count++;
-
-					$checked = '';
-					if ( in_array( $i, $selected_conditions ) ) {
-						$checked = ' checked="checked"';
-					}
-					$tab .= '<li><label class="selectit" title="' . esc_attr( $j['description'] ) . '"><input type="checkbox" name="conditions[]" value="' . $i . '" id="checkbox-' . $i . '"' . $checked . ' /> ' . esc_html( $j['label'] ) . '</label></li>' . "\n";
-
-					if ( $count % 10 == 0 && $count < ( count( $v ) ) ) {
-						$tab .= '</ul><ul class="alignleft conditions-column">';
-					}
+			foreach ( $v as $i => $j ) {
+				$depth = '';
+				if ( isset( $j['depth'] ) ) {
+					$depth = str_repeat( '&nbsp;', $j['depth'] * 3 );
 				}
+				$count++;
+
+				$checked = '';
+				if ( in_array( $i, $selected_conditions ) ) {
+					$checked = ' checked="checked"';
+				}
+				$tab .= '<li><label class="selectit" title="' . esc_attr( $j['description'] ) . '">' . $depth . '<input type="checkbox" name="conditions[]" value="' . $i . '" id="checkbox-' . $i . '"' . $checked . ' /> ' . esc_html( $j['label'] ) . '</label></li>' . "\n";
+
+				if ( $count % 10 == 0 && $count < ( count( $v ) ) ) {
+					$tab .= '</ul><ul class="alignleft conditions-column">';
+				}
+			}
 
 			$tab .= '</ul>' . "\n";
 			// Filter the contents of the current tab.

--- a/classes/class-woo-conditions.php
+++ b/classes/class-woo-conditions.php
@@ -274,7 +274,7 @@ class Woo_Conditions {
 
 					// Setup each individual taxonomy's terms as well.
 					$conditions_headings['taxonomy-' . $k] = $taxonomy->labels->name;
-					$terms = get_terms( $k );
+					$terms = get_terms( array( 'taxonomy' => $k, 'hide_empty' => false ) );
 					if ( count( $terms ) > 0 ) {
 						$conditions['taxonomy-' . $k] = array();
 						foreach ( $terms as $i => $j ) {

--- a/classes/class-woo-conditions.php
+++ b/classes/class-woo-conditions.php
@@ -569,127 +569,12 @@ class Woo_Conditions {
 
 			$html .= '<div id="taxonomy-category" class="categorydiv tabs woo-conditions">' . "\n";
 
-				$html .= '<ul id="category-tabs" class="conditions-tabs alignleft">' . "\n";
+			$html .= $this->render_tabs( $selected_conditions );
 
-				$count = 0;
+			$html .= $this->render_standard_pages( $selected_conditions );
 
-				// Determine whether or not to show advanced items, based on user's preference (default: false).
-				$show_advanced = $this->show_advanced_items();
+			$html .= $this->render_taxonomy_terms_tabs( $taxonomy_terms, $selected_conditions );
 
-				foreach ( $this->conditions_reference as $k => $v ) {
-					$count++;
-					$class = '';
-					if ( $count == 1 ) {
-						$class = 'tabs';
-					} else {
-						$class = 'hide-if-no-js';
-					}
-					if ( in_array( $k, array( 'pages' ) ) ) {
-						$class .= ' basic';
-					} else {
-							$class .= ' advanced';
-							if ( ! $show_advanced ) { $class .= ' hide'; }
-					}
-
-					if ( isset( $this->conditions_headings[$k] ) ) {
-						$html .= '<li class="' . esc_attr( $class ) . '"><a href="#tab-' . esc_attr( $k ) . '">' . esc_html( $this->conditions_headings[$k] ) . '</a></li>' . "\n";
-					}
-
-					if ( $k == 'taxonomies' ) {
-						$html .= '<li class="' . esc_attr( $class ) . '"><a href="#tab-taxonomy-terms">' . __( 'Taxonomy Terms', 'woosidebars' ) . '</a></li>' . "\n";
-					}
-				}
-
-				$class = 'hide-if-no-js advanced';
-				if ( ! $show_advanced ) { $class .= ' hide'; }
-
-				$html .= '</ul>' . "\n";
-
-				$html .= '<ul class="conditions-tabs"><li class="advanced-settings alignright hide-if-no-js"><a href="#">' . __( 'Advanced', 'woosidebars' ) . '</a></li></ul>' . "\n";
-
-			foreach ( $this->conditions_reference as $k => $v ) {
-				$count = 0;
-
-				$tab = '';
-
-				$tab .= '<div id="tab-' . esc_attr( $k ) . '" class="condition-tab">' . "\n";
-				if ( isset( $this->conditions_headings[$k] ) ) {
-					$tab .= '<h4>' . esc_html( $this->conditions_headings[$k] ) . '</h4>' . "\n";
-				}
-				$tab .= '<ul class="alignleft conditions-column">' . "\n";
-					foreach ( $v as $i => $j ) {
-						$count++;
-
-						$checked = '';
-						if ( in_array( $i, $selected_conditions ) ) {
-							$checked = ' checked="checked"';
-						}
-						$tab .= '<li><label class="selectit" title="' . esc_attr( $j['description'] ) . '"><input type="checkbox" name="conditions[]" value="' . $i . '" id="checkbox-' . $i . '"' . $checked . ' /> ' . esc_html( $j['label'] ) . '</label></li>' . "\n";
-
-						if ( $count % 10 == 0 && $count < ( count( $v ) ) ) {
-							$tab .= '</ul><ul class="alignleft conditions-column">';
-						}
-					}
-
-				$tab .= '</ul>' . "\n";
-				// Filter the contents of the current tab.
-				$tab = apply_filters( 'woo_conditions_tab_' . esc_attr( $k ), $tab );
-				$html .= $tab;
-				$html .= '<div class="clear"></div>';
-				$html .= '</div>' . "\n";
-			}
-
-			// Taxonomy Terms Tab
-			$html .= '<div id="tab-taxonomy-terms" class="condition-tab inner-tabs">' . "\n";
-					$html .= '<ul class="conditions-tabs-inner hide-if-no-js">' . "\n";
-
-				foreach ( $taxonomy_terms as $k => $v ) {
-					if ( ! isset( $this->conditions_headings[$k] ) ) { unset( $taxonomy_terms[$k] ); }
-				}
-
-				$count = 0;
-				foreach ( $taxonomy_terms as $k => $v ) {
-					$count++;
-					$class = '';
-					if ( $count == 1 ) {
-						$class = 'tabs';
-					} else {
-						$class = 'hide-if-no-js';
-					}
-
-					$html .= '<li><a href="#tab-' . $k . '" title="' . __( 'Taxonomy Token', 'woosidebars' ) . ': ' . str_replace( 'taxonomy-', '', $k ) . '">' . esc_html( $this->conditions_headings[$k] ) . '</a>';
-						if ( $count != count( $taxonomy_terms ) ) {
-							$html .= ' |';
-						}
-					$html .= '</li>' . "\n";
-				}
-
-				$html .= '</ul>' . "\n";
-
-			foreach ( $taxonomy_terms as $k => $v ) {
-				$count = 0;
-
-				$html .= '<div id="tab-' . $k . '" class="condition-tab">' . "\n";
-				$html .= '<h4>' . esc_html( $this->conditions_headings[$k] ) . '</h4>' . "\n";
-				$html .= '<ul class="alignleft conditions-column">' . "\n";
-					foreach ( $v as $i => $j ) {
-						$count++;
-
-						$checked = '';
-						if ( in_array( $i, $selected_conditions ) ) {
-							$checked = ' checked="checked"';
-						}
-						$html .= '<li><label class="selectit" title="' . esc_attr( $j['description'] ) . '"><input type="checkbox" name="conditions[]" value="' . $i . '" id="checkbox-' . esc_attr( $i ) . '"' . $checked . ' /> ' . esc_html( $j['label'] ) . '</label></li>' . "\n";
-
-						if ( $count % 10 == 0 && $count < ( count( $v ) ) ) {
-							$html .= '</ul><ul class="alignleft conditions-column">';
-						}
-					}
-
-				$html .= '</ul>' . "\n";
-				$html .= '<div class="clear"></div>';
-				$html .= '</div>' . "\n";
-			}
 			$html .= '</div>' . "\n";
 		}
 
@@ -700,6 +585,143 @@ class Woo_Conditions {
 
 		echo $html;
 	} // End meta_box_content()
+
+	private function render_tabs( $selected_conditions ) {
+		$html = '<ul id="category-tabs" class="conditions-tabs alignleft">' . "\n";
+
+		$count = 0;
+
+		// Determine whether or not to show advanced items, based on user's preference (default: false).
+		$show_advanced = $this->show_advanced_items();
+
+		foreach ( $this->conditions_reference as $k => $v ) {
+			$count++;
+			$class = '';
+			if ( $count == 1 ) {
+				$class = 'tabs';
+			} else {
+				$class = 'hide-if-no-js';
+			}
+			if ( in_array( $k, array( 'pages' ) ) ) {
+				$class .= ' basic';
+			} else {
+					$class .= ' advanced';
+					if ( ! $show_advanced ) { $class .= ' hide'; }
+			}
+
+			if ( isset( $this->conditions_headings[$k] ) ) {
+				$html .= '<li class="' . esc_attr( $class ) . '"><a href="#tab-' . esc_attr( $k ) . '">' . esc_html( $this->conditions_headings[$k] ) . '</a></li>' . "\n";
+			}
+
+			if ( $k == 'taxonomies' ) {
+				$html .= '<li class="' . esc_attr( $class ) . '"><a href="#tab-taxonomy-terms">' . __( 'Taxonomy Terms', 'woosidebars' ) . '</a></li>' . "\n";
+			}
+		}
+
+		$class = 'hide-if-no-js advanced';
+		if ( ! $show_advanced ) { $class .= ' hide'; }
+
+		$html .= '</ul>' . "\n";
+
+		$html .= '<ul class="conditions-tabs"><li class="advanced-settings alignright hide-if-no-js"><a href="#">' . __( 'Advanced', 'woosidebars' ) . '</a></li></ul>' . "\n";
+
+		return $html;
+	}
+
+	private function render_standard_pages( $selected_conditions ) {
+		$html = '';
+
+		foreach ( $this->conditions_reference as $k => $v ) {
+			$count = 0;
+
+			$tab = '';
+
+			$tab .= '<div id="tab-' . esc_attr( $k ) . '" class="condition-tab">' . "\n";
+			if ( isset( $this->conditions_headings[$k] ) ) {
+				$tab .= '<h4>' . esc_html( $this->conditions_headings[$k] ) . '</h4>' . "\n";
+			}
+			$tab .= '<ul class="alignleft conditions-column">' . "\n";
+				foreach ( $v as $i => $j ) {
+					$count++;
+
+					$checked = '';
+					if ( in_array( $i, $selected_conditions ) ) {
+						$checked = ' checked="checked"';
+					}
+					$tab .= '<li><label class="selectit" title="' . esc_attr( $j['description'] ) . '"><input type="checkbox" name="conditions[]" value="' . $i . '" id="checkbox-' . $i . '"' . $checked . ' /> ' . esc_html( $j['label'] ) . '</label></li>' . "\n";
+
+					if ( $count % 10 == 0 && $count < ( count( $v ) ) ) {
+						$tab .= '</ul><ul class="alignleft conditions-column">';
+					}
+				}
+
+			$tab .= '</ul>' . "\n";
+			// Filter the contents of the current tab.
+			$tab = apply_filters( 'woo_conditions_tab_' . esc_attr( $k ), $tab );
+			$html .= $tab;
+			$html .= '<div class="clear"></div>';
+			$html .= '</div>' . "\n";
+		}
+
+		return $html;
+	}
+
+	private function render_taxonomy_terms_tabs( $taxonomy_terms, $selected_conditions ) {
+		// Taxonomy Terms Tab
+		$html = '<div id="tab-taxonomy-terms" class="condition-tab inner-tabs">' . "\n";
+		$html .= '<ul class="conditions-tabs-inner hide-if-no-js">' . "\n";
+
+		foreach ( $taxonomy_terms as $k => $v ) {
+			if ( ! isset( $this->conditions_headings[$k] ) ) { unset( $taxonomy_terms[$k] ); }
+		}
+
+		$count = 0;
+		foreach ( $taxonomy_terms as $k => $v ) {
+			$count++;
+			$class = '';
+			if ( $count == 1 ) {
+				$class = 'tabs';
+			} else {
+				$class = 'hide-if-no-js';
+			}
+
+			$html .= '<li><a href="#tab-' . $k . '" title="' . __( 'Taxonomy Token', 'woosidebars' ) . ': ' . str_replace( 'taxonomy-', '', $k ) . '">' . esc_html( $this->conditions_headings[$k] ) . '</a>';
+				if ( $count != count( $taxonomy_terms ) ) {
+					$html .= ' |';
+				}
+			$html .= '</li>' . "\n";
+		}
+
+		$html .= '</ul>' . "\n";
+
+		foreach ( $taxonomy_terms as $k => $v ) {
+			$count = 0;
+
+			$html .= '<div id="tab-' . $k . '" class="condition-tab">' . "\n";
+			$html .= '<h4>' . esc_html( $this->conditions_headings[$k] ) . '</h4>' . "\n";
+			$html .= '<ul class="alignleft conditions-column">' . "\n";
+
+			foreach ( $v as $i => $j ) {
+				$count++;
+
+				$checked = '';
+				if ( in_array( $i, $selected_conditions ) ) {
+					$checked = ' checked="checked"';
+				}
+				$html .= '<li><label class="selectit" title="' . esc_attr( $j['description'] ) . '"><input type="checkbox" name="conditions[]" value="' . $i . '" id="checkbox-' . esc_attr( $i ) . '"' . $checked . ' /> ' . esc_html( $j['label'] ) . '</label></li>' . "\n";
+
+				if ( $count % 10 == 0 && $count < ( count( $v ) ) ) {
+					$html .= '</ul><ul class="alignleft conditions-column">';
+				}
+			}
+
+			$html .= '</ul>' . "\n";
+			$html .= '<div class="clear"></div>';
+			$html .= '</div>' . "\n";
+
+		}
+		return $html;
+	}
 
 	/**
 	 * meta_box_save function.

--- a/classes/class-woo-conditions.php
+++ b/classes/class-woo-conditions.php
@@ -428,6 +428,13 @@ class Woo_Conditions {
 
 			// Post-specific condition.
 			$this->conditions[] = 'post' . '-' . get_the_ID();
+			$this->conditions[] = 'postwc' . '-' . get_the_ID();
+		}
+
+		$ancestors = get_post_ancestors( get_the_ID() );
+
+		foreach ( $ancestors as $ancestor ) {
+			$this->conditions[] = 'postwc-' . $ancestor;
 		}
 
 		if ( is_search() ) {

--- a/classes/class-woo-conditions.php
+++ b/classes/class-woo-conditions.php
@@ -141,6 +141,33 @@ class Woo_Conditions {
 
 		}
 
+
+		// Pages and their children
+		$conditions['pages_with_children'] = array();
+
+		$statuses_string = join( ',', array_keys( $post_statuses ) );
+		$pages = get_pages( array( 'post_status' => $statuses_string ) );
+
+		if ( count( $pages ) > 0 ) {
+
+			$conditions_headings['pages_with_children'] = __( 'Pages and their children', 'woosidebars' );
+
+			foreach ( $pages as $k => $v ) {
+				$token = 'postwc-' . $v->ID;
+				$label = esc_html( $v->post_title );
+				if ( 'publish' != $v->post_status ) {
+					$label .= ' (' . $post_statuses[$v->post_status] . ')';
+				}
+
+				$conditions['pages_with_children'][$token] = array(
+									'label' => $label,
+									'description' => sprintf( __( 'The "%s" page and its children', 'woosidebars' ), $v->post_title )
+									);
+			}
+
+		}
+
+
 		$args = array(
 					'show_ui' => true,
 					'public' => true,

--- a/classes/class-woo-conditions.php
+++ b/classes/class-woo-conditions.php
@@ -367,6 +367,7 @@ class Woo_Conditions {
 									'description' => __( 'Displayed on all 404 error screens.', 'woosidebars' )
 									);
 
+
 		$this->conditions_reference = (array)apply_filters( 'woo_conditions_reference', $conditions );
 		$this->conditions_headings = (array)apply_filters( 'woo_conditions_headings', $conditions_headings );
 	} // End setup_default_conditions_reference()

--- a/classes/class-woo-conditions.php
+++ b/classes/class-woo-conditions.php
@@ -550,12 +550,19 @@ class Woo_Conditions {
 
 		if ( count( $this->conditions_reference ) > 0 ) {
 
-			// Separate out the taxonomy items for use as sub-tabs of "Taxonomy Terms".
+			// Separate out the taxonomy items and pages with children for use as sub-tabs of "Taxonomy Terms" and hierarchical presentation of pages
 			$taxonomy_terms = array();
+			$pwc = array();
+
 
 			foreach ( $this->conditions_reference as $k => $v ) {
 				if ( substr( $k, 0, 9 ) == 'taxonomy-' ) {
 					$taxonomy_terms[$k] = $v;
+					unset( $this->conditions_reference[$k] );
+				}
+
+				if ( 'pages_with_children' === $k ) {
+					$pwc[$k] = $v;
 					unset( $this->conditions_reference[$k] );
 				}
 			}

--- a/classes/class-woo-conditions.php
+++ b/classes/class-woo-conditions.php
@@ -434,14 +434,6 @@ class Woo_Conditions {
 			$this->conditions[] = 'search';
 		}
 
-		if ( is_home() ) {
-			$this->conditions[] = 'home';
-		}
-
-		if ( is_front_page() ) {
-			$this->conditions[] = 'front_page';
-		}
-
 		if ( is_archive() ) {
 			$this->conditions[] = 'archive';
 		}

--- a/classes/class-woo-sidebars.php
+++ b/classes/class-woo-sidebars.php
@@ -167,7 +167,7 @@ class Woo_Sidebars {
 			'new_item' => sprintf( __( 'New %s', 'woosidebars' ), $singular ),
 			'all_items' => sprintf( __( 'Widget Areas', 'woosidebars' ), $plural ),
 			'view_item' => sprintf( __( 'View %s', 'woosidebars' ), $singular ),
-			'search_items' => sprintf( __( 'Search %a', 'woosidebars' ), $plural ),
+			'search_items' => sprintf( __( 'Search %s', 'woosidebars' ), $plural ),
 			'not_found' =>  sprintf( __( 'No %s Found', 'woosidebars' ), $plural ),
 			'not_found_in_trash' => sprintf( __( 'No %s Found In Trash', 'woosidebars' ), $plural ),
 			'parent_item_colon' => '',

--- a/classes/class-woo-sidebars.php
+++ b/classes/class-woo-sidebars.php
@@ -498,7 +498,7 @@ class Woo_Sidebars {
 		 	$args = array(
 		 		'post_type' => $this->token,
 		 		'posts_per_page' => intval( $this->upper_limit ),
-		 		'suppress_filters' => 'false'
+		 		'suppress_filters' => true
 		 	);
 
 		 	$meta_query = array(
@@ -521,6 +521,12 @@ class Woo_Sidebars {
 
 		 	if ( count( $sidebars ) > 0 ) {
 		 		foreach ( $sidebars as $k => $v ) {
+
+		 			// get the post language
+					$wpml_element = apply_filters( 'wpml_element_language_code', ICL_LANGUAGE_CODE, array( 'element_id' => $v->ID, 'element_type' => 'post_sidebar' ) );	
+					// check if the current language matches the language of the sidebar
+					if( $wpml_element != ICL_LANGUAGE_CODE ) continue;
+
 		 			$to_replace = get_post_meta( $v->ID, '_sidebar_to_replace', true );
 		 			$sidebars[$k]->to_replace = $to_replace;
 

--- a/classes/class-woo-sidebars.php
+++ b/classes/class-woo-sidebars.php
@@ -740,7 +740,7 @@ class Woo_Sidebars {
 	 * @return void
 	 */
 	public function add_contextual_help () {
-		if ( get_current_screen()->id != 'edit-sidebar' ) { return; }
+		if ( ! get_current_screen() || get_current_screen()->id != 'edit-sidebar' ) { return; }
 
 		get_current_screen()->add_help_tab( array(
 		'id'		=> 'overview',

--- a/classes/class-woo-sidebars.php
+++ b/classes/class-woo-sidebars.php
@@ -740,7 +740,7 @@ class Woo_Sidebars {
 	 * @return void
 	 */
 	public function add_contextual_help () {
-		if ( ! get_current_screen() || get_current_screen()->id != 'edit-sidebar' ) { return; }
+		if ( empty( get_current_screen() ) || get_current_screen()->id != 'edit-sidebar' ) { return; }
 
 		get_current_screen()->add_help_tab( array(
 		'id'		=> 'overview',

--- a/classes/class-woo-sidebars.php
+++ b/classes/class-woo-sidebars.php
@@ -453,10 +453,10 @@ class Woo_Sidebars {
 
 		if ( count( $sidebars ) > 0 ) {
 			foreach ( $sidebars as $k => $v ) {
-				$args = apply_filters( 'woosidebars_sidebar_args', array( 
-					'name'        => $v->post_title, 
-					'id'          => $v->post_name, 
-					'description' => $v->post_excerpt, 
+				$args = apply_filters( 'woosidebars_sidebar_args', array(
+					'name'        => $v->post_title,
+					'id'          => $v->post_name,
+					'description' => $v->post_excerpt,
 				), $v, $this );
 				register_sidebar( $args );
 			}
@@ -525,10 +525,14 @@ class Woo_Sidebars {
 		 	if ( count( $sidebars ) > 0 ) {
 		 		foreach ( $sidebars as $k => $v ) {
 
-		 			// get the post language
-					$wpml_element = apply_filters( 'wpml_element_language_code', ICL_LANGUAGE_CODE, array( 'element_id' => $v->ID, 'element_type' => 'post_sidebar' ) );	
-					// check if the current language matches the language of the sidebar
-					if( $wpml_element != ICL_LANGUAGE_CODE ) continue;
+					if ( defined( 'ICL_LANGUAGE_CODE' ) ) {
+						// get the post language
+						$wpml_element = apply_filters( 'wpml_element_language_code', ICL_LANGUAGE_CODE, array( 'element_id' => intval( $v->ID ), 'element_type' => 'post_sidebar' ) );
+						// check if the current language matches the language of the sidebar
+						if ( $wpml_element != ICL_LANGUAGE_CODE ) {
+								continue;
+						}
+					}
 
 		 			$to_replace = get_post_meta( $v->ID, '_sidebar_to_replace', true );
 		 			$sidebars[$k]->to_replace = $to_replace;

--- a/classes/class-woo-sidebars.php
+++ b/classes/class-woo-sidebars.php
@@ -375,10 +375,10 @@ class Woo_Sidebars {
 	 * @param object $post
 	 */
 	public function description_meta_box ( $post ) {
-	?>
-	<label class="screen-reader-text" for="excerpt"><?php _e( 'Description', 'woosidebars' ); ?></label><textarea rows="1" cols="40" name="excerpt" tabindex="6" id="excerpt"><?php echo $post->post_excerpt; // textarea_escaped ?></textarea>
-	<p><?php printf( __( 'Add an optional description, to be displayed when adding widgets to this widget area on the %sWidgets%s screen.', 'woosidebars' ), '<a href="' . esc_url( admin_url( 'widgets.php' ) ) . '">', '</a>' ); ?></p>
-	<?php
+		?>
+		<label class="screen-reader-text" for="excerpt"><?php _e( 'Description', 'woosidebars' ); ?></label><textarea rows="1" cols="40" name="excerpt" tabindex="6" id="excerpt"><?php echo $post->post_excerpt; // textarea_escaped ?></textarea>
+		<p><?php printf( __( 'Add an optional description, to be displayed when adding widgets to this widget area on the %sWidgets%s screen.', 'woosidebars' ), '<a href="' . esc_url( admin_url( 'widgets.php' ) ) . '">', '</a>' ); ?></p>
+		<?php
 	} // End description_meta_box()
 
 	/**

--- a/classes/class-woo-sidebars.php
+++ b/classes/class-woo-sidebars.php
@@ -453,9 +453,12 @@ class Woo_Sidebars {
 
 		if ( count( $sidebars ) > 0 ) {
 			foreach ( $sidebars as $k => $v ) {
-				$sidebar_id = $v->post_name;
-				// $sidebar_id = $this->prefix . $v->ID;
-				register_sidebar( array( 'name' => $v->post_title, 'id' => $sidebar_id, 'description' => $v->post_excerpt ) );
+				$args = apply_filters( 'woosidebars_sidebar_args', array( 
+					'name'        => $v->post_title, 
+					'id'          => $v->post_name, 
+					'description' => $v->post_excerpt, 
+				), $v, $this );
+				register_sidebar( $args );
 			}
 		}
 	} // End register_custom_sidebars()

--- a/classes/class-woo-sidebars.php
+++ b/classes/class-woo-sidebars.php
@@ -46,7 +46,6 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
  * - add_post_column_data()
  * - enable_custom_post_sidebars()
  * - multidimensional_search()
- * - add_contextual_help()
  *
  * - load_localisation()
  * - activation()
@@ -107,7 +106,6 @@ class Woo_Sidebars {
 			global $pagenow;
 
 			add_action( 'admin_print_styles', array( $this, 'enqueue_styles' ), 12 );
-			add_action( 'admin_head', array( $this, 'add_contextual_help' ) );
 			if ( $pagenow == 'edit.php' && isset( $_GET['post_type'] ) && esc_attr( $_GET['post_type'] ) == $this->token ) {
 				add_filter( 'manage_edit-' . $this->token . '_columns', array( $this, 'register_custom_column_headings' ), 10, 1 );
 				add_action( 'manage_posts_custom_column', array( $this, 'register_custom_columns' ), 10, 2 );
@@ -743,44 +741,6 @@ class Woo_Sidebars {
 
         return false;
 	} // End multidimensional_search()
-
-	/**
-	 * add_contextual_help function.
-	 *
-	 * @description Add contextual help to the current screen.
-	 * @access public
-	 * @since 1.0.0
-	 * @return void
-	 */
-	public function add_contextual_help () {
-		if ( empty( get_current_screen() ) || get_current_screen()->id != 'edit-sidebar' ) { return; }
-
-		get_current_screen()->add_help_tab( array(
-		'id'		=> 'overview',
-		'title'		=> __( 'Overview', 'woosidebars' ),
-		'content'	=>
-			'<p>' . __( 'All custom widget areas are listed on this screen. To add a new customised widget area, click the "Add New" button.', 'woosidebars' ) . '</p>'
-		) );
-		get_current_screen()->add_help_tab( array(
-		'id'		=> 'wooframework-sbm',
-		'title'		=> __( 'Sidebar Manager', 'woosidebars' ),
-		'content'	=>
-			'<p>' . __( 'WooSidebars is intended to replace the Sidebar Manager found in the WooFramework. Please ensure that all sidebars have been transferred over from the Sidebar Manager, if you choose to use WooSidebars instead.', 'woosidebars' ) . '</p>' .
-			'<p>' . __( 'To transfer a sidebar from the Sidebar Manager:', 'woosidebars' ) . '</p>' .
-			'<ul>' . "\n" .
-			'<li>' . __( 'Create a new custom widget area in WooSidebars.', 'woosidebars' ) . '</li>' . "\n" .
-			'<li>' . sprintf( __( 'Visit the %sAppearance &rarr; Widgets%s screen and drag the widgets from the old sidebar into the newly created sidebar.', 'woosidebars' ), '<a href="' . esc_url( admin_url( 'widgets.php' ) ) . '">', '</a>' ) . '</li>' . "\n" .
-			'<li>' . __( 'Repeat this process for each of your custom sidebars, including dependencies if necessary (the WooSidebars conditions system replaces the need for dependencies).', 'woosidebars' ) . '</li>' . "\n" .
-			'<li>' . __( 'Once you are certain that you widgets have been moved across for all widget areas, remove the sidebar from the Sidebar Manager (don\'t forget to transfer any dependencies over as well, if necessary).', 'woosidebars' ) . '</li>' . "\n" .
-			'</ul>' . "\n"
-		) );
-
-		get_current_screen()->set_help_sidebar(
-		'<p><strong>' . __( 'For more information:', 'woosidebars' ) . '</strong></p>' .
-		'<p><a href="http://support.woothemes.com/?ref=' . 'woosidebars' . '" target="_blank">' . __( 'Support HelpDesk', 'woosidebars' ) . '</a></p>' .
-		'<p><a href="http://docs.woothemes.com/document/woosidebars/?ref=' . 'woosidebars' . '" target="_blank">' . __( 'WooSidebars Documentation', 'woosidebars' ) . '</a></p>'
-		);
-	} // End add_contextual_help()
 
 	/**
 	 * load_localisation function.

--- a/readme.txt
+++ b/readme.txt
@@ -1,9 +1,9 @@
 === WooSidebars ===
-Contributors: woothemes, mattyza
+Contributors: woothemes, Automattic, mattyza
 Tags: widgets, sidebars, widget-areas
 Requires at least: 4.1
-Tested up to: 4.6.1
-Stable tag: 1.4.3
+Tested up to: 4.6.5
+Stable tag: 1.4.4
 License: GPLv3 or later
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -69,6 +69,9 @@ Looking to contribute code to this plugin? [Fork the repository over at GitHub](
 
 == Upgrade Notice ==
 
+= 1.4.4 =
+Bug fix and maintenance release. Enables "pages and their children" as a widget area condition.
+
 = 1.4.3 =
 Bug fix and maintenance release.
 
@@ -98,6 +101,10 @@ Updated for WordPress 3.5+ compatibility. Adjusted "Advanced" tab logic. Fixed b
 Moved to WordPress.org. Woo! Added scope to methods and properties where missing.
 
 == Changelog ==
+
+= 1.4.4 =
+* 2018-06-08
+* Bug fix and maintenance release. Enables "pages and their children" as a widget area condition.
 
 = 1.4.3 =
 * 2015-09-22

--- a/readme.txt
+++ b/readme.txt
@@ -29,7 +29,7 @@ Looking to contribute code to this plugin? [Fork the repository over at GitHub](
 
 Automatic installation is the easiest option as WordPress handles the file transfers itself and you don’t even need to leave your web browser. To do an automatic install of WooSidebars, log in to your WordPress admin panel, navigate to the Plugins menu and click Add New.
 
-In the search field type "WooSidebars" and click Search Plugins. Once you’ve found our widget areas plugin you can view details about it such as the the point release, rating and description. Most importantly of course, you can install it by simply clicking Install Now. After clicking that link you will be asked if you’re sure you want to install the plugin. Click yes and WordPress will automatically complete the installation.
+In the search field type "WooSidebars" and click Search Plugins. Once you’ve found our widget areas plugin you can view details about it such as the point release, rating and description. Most importantly of course, you can install it by simply clicking Install Now. After clicking that link you will be asked if you’re sure you want to install the plugin. Click yes and WordPress will automatically complete the installation.
 
 = Manual installation =
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: woothemes, Automattic, mattyza
 Tags: widgets, sidebars, widget-areas
 Requires at least: 4.1
 Tested up to: 4.6.5
-Stable tag: 1.4.4
+Stable tag: 1.4.5
 License: GPLv3 or later
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -69,6 +69,9 @@ Looking to contribute code to this plugin? [Fork the repository over at GitHub](
 
 == Upgrade Notice ==
 
+= 1.4.5 =
+Fixes a fatal error, by removing the no longer relevant contextual help.
+
 = 1.4.4 =
 Bug fix and maintenance release. Enables "pages and their children" as a widget area condition.
 
@@ -101,6 +104,10 @@ Updated for WordPress 3.5+ compatibility. Adjusted "Advanced" tab logic. Fixed b
 Moved to WordPress.org. Woo! Added scope to methods and properties where missing.
 
 == Changelog ==
+
+= 1.4.5 =
+* 2018-06-18
+* Fixes a fatal error, by removing the no longer relevant contextual help.
 
 = 1.4.4 =
 * 2018-06-08

--- a/woosidebars.php
+++ b/woosidebars.php
@@ -14,18 +14,21 @@
  * Domain Path: /lang
  */
 
- if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
 
- if ( ! class_exists( 'Woo_Conditions' ) ) {
- 	require_once( 'classes/class-woo-conditions.php' );
- }
- require_once( 'classes/class-woo-sidebars.php' );
+if ( ! class_exists( 'Woo_Conditions' ) ) {
+	require_once( 'classes/class-woo-conditions.php' );
+}
+require_once( 'classes/class-woo-sidebars.php' );
 
- // Third-party integrations.
- if ( class_exists( 'Woocommerce' ) ) require_once( 'integrations/integration-woocommerce.php' );
+// Third-party integrations.
+if ( class_exists( 'Woocommerce' ) ) {
+	require_once( 'integrations/integration-woocommerce.php' );
+}
 
- global $woosidebars;
- $woosidebars = new Woo_Sidebars( __FILE__ );
- $woosidebars->version = '1.4.3';
- $woosidebars->init();
-?>
+global $woosidebars;
+$woosidebars = new Woo_Sidebars( __FILE__ );
+$woosidebars->version = '1.4.3';
+$woosidebars->init();

--- a/woosidebars.php
+++ b/woosidebars.php
@@ -1,14 +1,14 @@
 <?php
 /**
  * Plugin Name: WooSidebars
- * Plugin URI: http://woothemes.com/woosidebars/
+ * Plugin URI: http://woocommerce.com/woosidebars/
  * Description: Replace widget areas in your theme for specific pages, archives and other sections of WordPress.
- * Author: WooThemes
- * Author URI: http://woothemes.com/
- * Version: 1.4.3
- * Stable tag: 1.4.3
+ * Author: WooCommerce
+ * Author URI: http://woocommerce.com/
+ * Version: 1.4.4
+ * Stable tag: 1.4.4
  * Requires at least: 4.1
- * Tested up to: 4.6.1
+ * Tested up to: 4.6.5
  * License: GPL v3 or later - http://www.gnu.org/licenses/gpl-3.0.html
  * Text Domain: woosidebars
  * Domain Path: /lang
@@ -30,5 +30,5 @@ if ( class_exists( 'Woocommerce' ) ) {
 
 global $woosidebars;
 $woosidebars = new Woo_Sidebars( __FILE__ );
-$woosidebars->version = '1.4.3';
+$woosidebars->version = '1.4.4';
 $woosidebars->init();

--- a/woosidebars.php
+++ b/woosidebars.php
@@ -5,8 +5,8 @@
  * Description: Replace widget areas in your theme for specific pages, archives and other sections of WordPress.
  * Author: WooCommerce
  * Author URI: http://woocommerce.com/
- * Version: 1.4.4
- * Stable tag: 1.4.4
+ * Version: 1.4.5
+ * Stable tag: 1.4.5
  * Requires at least: 4.1
  * Tested up to: 4.6.5
  * License: GPL v3 or later - http://www.gnu.org/licenses/gpl-3.0.html
@@ -30,5 +30,5 @@ if ( class_exists( 'Woocommerce' ) ) {
 
 global $woosidebars;
 $woosidebars = new Woo_Sidebars( __FILE__ );
-$woosidebars->version = '1.4.4';
+$woosidebars->version = '1.4.5';
 $woosidebars->init();


### PR DESCRIPTION
In line 170, the sprintf() function contained the phrase 'Search %a', causing a fatal error in WordPress when updating to PHP 8. The issue was resolved by changing '%a' to '%s'.